### PR TITLE
Refine active workout route

### DIFF
--- a/lib/presentation/active_workout/active_workout_route.dart
+++ b/lib/presentation/active_workout/active_workout_route.dart
@@ -9,6 +9,8 @@ import 'package:stronk/presentation/component/exercise_row.dart';
 import 'component/workout_clock.dart';
 
 class ActiveWorkoutRoute extends StatelessWidget {
+  final appbarBackground = Colors.red[300];
+
   @override
   Widget build(BuildContext context) => BlocProvider(
         create: (context) {
@@ -16,72 +18,70 @@ class ActiveWorkoutRoute extends StatelessWidget {
           return ActiveWorkoutBloc(workoutRepo: workoutRepo);
         },
         child: BlocBuilder<ActiveWorkoutBloc, ActiveWorkoutState>(
-          builder: (context, workoutState) => Scaffold(
-              body: Column(children: [
-            Center(
-              child: _renderHeader(
-                BlocProvider.of<ActiveWorkoutBloc>(context),
-                workoutState,
-              ),
-            ),
-            _renderExercisesViewPager(workoutState)
-          ])),
-        ),
+            builder: (context, workoutState) => DefaultTabController(
+                  length: 2,
+                  child: Scaffold(
+                      appBar: PreferredSize(
+                        preferredSize: Size.fromHeight(260.0),
+                        child: AppBar(
+                          backgroundColor: appbarBackground,
+                          flexibleSpace: Center(
+                            child: _renderHeader(
+                              BlocProvider.of<ActiveWorkoutBloc>(context),
+                              workoutState,
+                            ),
+                          ),
+                          bottom: TabBar(
+                            tabs: [Text("Remaining"), Text("Completed")],
+                          ),
+                        ),
+                      ),
+                      body: Column(children: [
+                        _renderTabBarView(workoutState),
+                      ])),
+                )),
       );
 
   // widget for rendering the "current" workout header
-  Widget _renderHeader(
-      ActiveWorkoutBloc bloc, ActiveWorkoutState workoutState) {
-
+  Widget _renderHeader(ActiveWorkoutBloc bloc, ActiveWorkoutState workoutState) {
     if (workoutState.workoutRef == null)
-      return Container(
-          child:
-              Text("Retrieving workout")); // TODO show workout completed card
+      return Container(child: Text("Retrieving workout")); // TODO show workout completed card
 
     // TODO create "completed exercise view
-    if (workoutState.completed)
-      return Container(
-          child:
-          Text("Completed Workout!"));
+    if (workoutState.completed) return Container(child: Text("Completed Workout!"));
 
     var completedExerciseCount = 0;
     var remainingExerciseCount = 0;
 
     if (workoutState.exerciseRecords != null) {
-      remainingExerciseCount = workoutState.exerciseRecords
-          .where((exercise) => exercise.status == Status.Incomplete)
-          .length;
+      remainingExerciseCount =
+          workoutState.exerciseRecords.where((exercise) => exercise.status == Status.Incomplete).length;
 
-      completedExerciseCount = workoutState.exerciseRecords
-          .where((exercise) => exercise.status != Status.Incomplete)
-          .length;
+      completedExerciseCount =
+          workoutState.exerciseRecords.where((exercise) => exercise.status != Status.Incomplete).length;
     }
 
-    final currentExercise =
-        workoutState.exerciseRecords[workoutState.currentExerciseIndex];
-    final currentSet =
-        currentExercise.exerciseSets[workoutState.currentSetIndex];
+    final currentExercise = workoutState.exerciseRecords[workoutState.currentExerciseIndex];
+    final currentSet = currentExercise.exerciseSets[workoutState.currentSetIndex];
 
     final totalExerciseCount = completedExerciseCount + remainingExerciseCount;
-    final exerciseCard =
-        (workoutState.workoutRef == null) // TODO show workout completed card
-            ? Container(child: Text("Retrieving workout"))
-            : Dismissible(
-                key: UniqueKey(),
-                child: CurrentExerciseCard(
-                    workoutExercise: currentExercise, exerciseSet: currentSet),
-                onDismissed: (direction) {
-                  // left swipe
-                  if (direction == DismissDirection.endToStart) {
-                    // TODO add popup for selecting reps before failure
-                     bloc.add(new FailExerciseEvent(0));
-                  }
-                  // right swipe
-                  else if (direction == DismissDirection.startToEnd) {
-                    bloc.add(new CompleteExerciseEvent());
-                  }
-                },
-              );
+    final exerciseCard = (workoutState.workoutRef == null) // TODO show workout completed card
+        ? Container(child: Text("Retrieving workout"))
+        : Dismissible(
+            key: UniqueKey(),
+            child: CurrentExerciseCard(workoutExercise: currentExercise, exerciseSet: currentSet),
+            onDismissed: (direction) {
+              // left swipe
+              if (direction == DismissDirection.endToStart) {
+                // TODO add popup for selecting reps before failure
+                bloc.add(new FailExerciseEvent(0));
+              }
+              // right swipe
+              else if (direction == DismissDirection.startToEnd) {
+                bloc.add(new CompleteExerciseEvent());
+              }
+            },
+          );
 
     return Container(
       height: 210,
@@ -89,10 +89,7 @@ class ActiveWorkoutRoute extends StatelessWidget {
       child: Column(
         children: <Widget>[
           WorkoutClock(),
-          Container(
-            height: 100,
-            child: exerciseCard
-          ),
+          Container(height: 100, child: exerciseCard),
           Text("Completed $completedExerciseCount/$totalExerciseCount exercises")
         ],
       ),
@@ -100,45 +97,49 @@ class ActiveWorkoutRoute extends StatelessWidget {
     );
   }
 
-  Widget _renderExercisesViewPager(ActiveWorkoutState workoutState) {
-    if (workoutState.workoutRef == null) return Container();
-    if (workoutState.completed) return Container();
+  Widget _renderTabBarView(ActiveWorkoutState workoutState) {
+    if (workoutState.workoutRef == null)
+      return TabBarView(
+        children: [Text("loading"), Text("loading")],
+      );
+    if (workoutState.completed)
+      return TabBarView(
+        children: [Text("loading"), Text("loading")],
+      );
 
-    final remainingFilter =
-        (setRecord) => setRecord.status == Status.Incomplete;
-    final completedFilter =
-        (setRecord) => setRecord.status != Status.Incomplete;
+    final remainingFilter = (setRecord) => setRecord.status == Status.Incomplete;
+    final completedFilter = (setRecord) => setRecord.status != Status.Incomplete;
 
-    final remainingExercisePage = _renderExercisePage(
-        workoutState.exerciseRecords, workoutState.setRecords, remainingFilter);
-    final completedExercisePage = _renderExercisePage(
-        workoutState.exerciseRecords, workoutState.setRecords, completedFilter);
+    final remainingExercisePage =
+        _renderExercisePage("Remaining", workoutState.exerciseRecords, workoutState.setRecords, remainingFilter);
+    final completedExercisePage =
+        _renderExercisePage("Completed", workoutState.exerciseRecords, workoutState.setRecords, completedFilter);
 
     // TODO render workout completed cart on remaining exercises screen
-    return Expanded(
-      child: PageView(children: [
-        remainingExercisePage,
-        completedExercisePage
-      ])
-    );
+//    return TabBarView(
+//      children: [remainingExercisePage, completedExercisePage],
+//    );
+
+    return Expanded(child: TabBarView(children: [remainingExercisePage, completedExercisePage]));
   }
 
-  Widget _renderExercisePage(List<ExerciseRecord> exercises,
-      List<List<SetRecord>> sets, bool filter(SetRecord e)) {
+  Widget _renderExercisePage(
+      title, List<ExerciseRecord> exercises, List<List<SetRecord>> sets, bool filter(SetRecord e)) {
     var setIndex = 0;
-    final exerciseCards = exercises.map((exercise) {
-      // get the list of set records satisfying predicate and create a new
-      // exercise record using only those sets
-      final setRecords = sets[setIndex].where(filter).toList();
-      setIndex += 1;
+    final exerciseCards = exercises
+        .map((exercise) {
+          // get the list of set records satisfying predicate and create a new
+          // exercise record using only those sets
+          final setRecords = sets[setIndex].where(filter).toList();
+          setIndex += 1;
 
-      return ExerciseRow(
-        workoutExercise: exercise,
-        setRecords: setRecords,
-      );
-    })
-    .where((exerciseRow)=>exerciseRow.setRecords.isNotEmpty)
-    .toList();
+          return ExerciseRow(
+            workoutExercise: exercise,
+            setRecords: setRecords,
+          );
+        })
+        .where((exerciseRow) => exerciseRow.setRecords.isNotEmpty)
+        .toList();
 
     return Container(
       child: ListView(

--- a/test/bloc/active_workout_bloc.dart
+++ b/test/bloc/active_workout_bloc.dart
@@ -59,6 +59,59 @@ void main() {
 
     activeWorkoutBloc.add(FailExerciseEvent(2));
   });
+
+  test("completed workout count is not incremented until all sets of an exercise are complete", () {
+    var mockWorkout = WorkoutRepositoryImpl.mockWorkout();
+    when(mockWorkoutRepo.retrieveWorkout()).thenAnswer((_) => Future.value(mockWorkout));
+
+    var matcher = TypeMatcher<ActiveWorkoutState>();
+
+    var matchEndState = (_) {
+      var failedWorkoutSet = activeWorkoutBloc.state.setRecords[0][0];
+      expect(failedWorkoutSet.repsBeforeFailure, 2);
+    };
+
+    expectLater(
+        activeWorkoutBloc,
+        emitsInOrder([
+          matcher.having((state) => state.workoutRef, "initially no workout ref", null),
+          matcher.having((state) => state.completedExerciseCount, "initial", 0),
+          matcher
+              .having((state) => state.completedExerciseCount, "0/3 sets completed", 0)
+              .having((state) => state.remainingExerciseCount, "3/3 exercises remaining", 3),
+    ])).then((_) => matchEndState);
+
+    activeWorkoutBloc.add(CompleteExerciseEvent());
+  });
+
+  test("completed workout count is incremented when all sets are completed for an exercise", () {
+    var mockWorkout = WorkoutRepositoryImpl.mockWorkout();
+    when(mockWorkoutRepo.retrieveWorkout()).thenAnswer((_) => Future.value(mockWorkout));
+
+    var matcher = TypeMatcher<ActiveWorkoutState>();
+
+    var matchEndState = (_) {
+      var failedWorkoutSet = activeWorkoutBloc.state.setRecords[0][0];
+      expect(failedWorkoutSet.repsBeforeFailure, 2);
+    };
+
+    expectLater(
+        activeWorkoutBloc,
+        emitsInOrder([
+          matcher.having((state) => state.workoutRef, "initially no workout ref", null),
+          matcher.having((state) => state.completedExerciseCount, "initial", 0),
+          matcher.having((state) => state.completedExerciseCount, "1/3 sets completed", 0),
+          matcher.having((state) => state.completedExerciseCount, "2/3 sets completed", 0),
+          matcher
+              .having((state) => state.completedExerciseCount, "3/3 sets completed", 1)
+              .having((state) => state.remainingExerciseCount, "2/3 exercises remaining", 2),
+
+        ])).then((_) => matchEndState);
+
+    activeWorkoutBloc.add(CompleteExerciseEvent());
+    activeWorkoutBloc.add(CompleteExerciseEvent());
+    activeWorkoutBloc.add(CompleteExerciseEvent());
+  });
 }
 
 class MockWorkoutRepo extends Mock implements WorkoutRepository {}


### PR DESCRIPTION
Replaces `ViewPager` used to render the remaining and completed workouts pages with a "TabLayout". This PR also adds a few additional changes: 

1. Restructures the active workout route so that the rendering of the page is extracted to a separate `buildPage` function. This ensures there's a clear distinction between the code used to construct the block provider and the code used to render the ui of the page.
2. Moves the logic of counting completed exercises to the bloc instead of the view and expose it through the UI. This is much cleaner and ensures we're not polluting our view with logic